### PR TITLE
Add a checkout of the called repo...

### DIFF
--- a/.github/workflows/search-indexer.yml
+++ b/.github/workflows/search-indexer.yml
@@ -51,6 +51,13 @@ jobs:
         with:
           ref: "${{ github.event.inputs.branch }}"
 
+      - name: checkout called workflow repo
+        uses: actions/checkout@v4
+        with:
+          repository: 'nationalarchives/ds-github-actions'
+          path: 'ds-github-actions'
+          ref: 'main'
+
       - name: Configure AWS Credentials
         id: creds
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
...by default when a calling repo reuses a workflow from another repo, any calls to "checkout" checkout only the calling repo.