### PR TITLE
Pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/backup-drop-zone-ami-build.yml
+++ b/.github/workflows/backup-drop-zone-ami-build.yml
@@ -38,26 +38,26 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-backup-kpf-administration/backup-drop-zone/${{ inputs.key_name }}
@@ -68,7 +68,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/beta-dw-ami-build.yml
+++ b/.github/workflows/beta-dw-ami-build.yml
@@ -51,27 +51,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/beta/${{ inputs.key_name }}
@@ -82,7 +82,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/beta-redis-ami-build.yml
+++ b/.github/workflows/beta-redis-ami-build.yml
@@ -46,27 +46,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/beta/${{ inputs.key_name }}
@@ -77,7 +77,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/beta-rp-ami-build.yml
+++ b/.github/workflows/beta-rp-ami-build.yml
@@ -57,27 +57,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/beta/${{ inputs.key_name }}
@@ -88,7 +88,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/blog-theme-deploy.yml
+++ b/.github/workflows/blog-theme-deploy.yml
@@ -41,18 +41,18 @@ jobs:
     steps:
       - name: checkout repo with release
         if: "${{ env.release != '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ env.release }}"
 
       - name: checkout repo with branch
         if: "${{ env.release == '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.branch }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: "${{ env.region }}"
@@ -106,7 +106,7 @@ jobs:
     environment: "${{ inputs.github-environment }}"
     steps:
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
 
@@ -117,7 +117,7 @@ jobs:
           cp scripts/requirements-aws-cli.txt .
 
       - name: Install AWS CLI
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -128,7 +128,7 @@ jobs:
           pip install -r scripts/requirements-aws-cli.txt
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: "${{ env.region }}"

--- a/.github/workflows/blog-wp-ami-build.yml
+++ b/.github/workflows/blog-wp-ami-build.yml
@@ -84,27 +84,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/blog/${{ inputs.key_name }}
@@ -115,7 +115,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/crawlguard-ami-build.yml
+++ b/.github/workflows/crawlguard-ami-build.yml
@@ -46,20 +46,20 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
@@ -78,7 +78,7 @@ jobs:
           echo "subnet_id=$SUBNET_ID" >> $GITHUB_OUTPUT
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/insights/${{ inputs.key_name }}
@@ -89,7 +89,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/da-x-posts-backup-ami-build.yml
+++ b/.github/workflows/da-x-posts-backup-ami-build.yml
@@ -33,26 +33,26 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-backup-kpf-administration/ds-x-post-backup/${{ inputs.key_name }}
@@ -63,7 +63,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -42,23 +42,23 @@ jobs:
       region: eu-west-2
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: eu-west-2
           role-to-assume: "${{ inputs.role-to-assume }}"
           role-session-name: MySessionName
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10' # Version range or exact version of a Python version to use, using SemVer's version range syntax
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.branch }}
 
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
       # only use if version freeze is in place
       #            with:
       #              terraform_version: 1.2.7
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: "${{ env.region }}"
@@ -175,7 +175,7 @@ jobs:
     environment: "${{ inputs.github-environment }}"
     steps:
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
 
@@ -184,7 +184,7 @@ jobs:
           cp scripts/requirements-aws-cli.txt .
 
       - name: Install AWS CLI
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -195,7 +195,7 @@ jobs:
           pip install -r scripts/requirements-aws-cli.txt
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: "${{ env.region }}"

--- a/.github/workflows/discovery-app-wincore.yml
+++ b/.github/workflows/discovery-app-wincore.yml
@@ -47,27 +47,27 @@ jobs:
     environment: ${{ inputs.account }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/discovery/${{ inputs.key_name }}
@@ -78,7 +78,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/discovery-compile-deploy.yml
+++ b/.github/workflows/discovery-compile-deploy.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: set credentials for AWS
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: "${{ secrets.AWS_CODEDEPLOY_ARN }}"
           aws-region: "${{ env.region }}"
@@ -49,18 +49,18 @@ jobs:
 
       - name: checkout repo with release
         if: "${{ env.release != '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ env.release }}"
 
       - name: checkout repo with branch
         if: "${{ env.release == '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.branch }}
 
       - name: add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
         with:
           msbuild-architecture: x64
 
@@ -119,7 +119,7 @@ jobs:
       region: "eu-west-2"
     steps:
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
 
@@ -130,7 +130,7 @@ jobs:
           cp scripts/requirements-aws-cli.txt .
 
       - name: Install AWS CLI
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -141,7 +141,7 @@ jobs:
           pip install -r scripts/requirements-aws-cli.txt
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEDEPLOY_ARN }}
           aws-region: "${{ env.region }}"

--- a/.github/workflows/discovery-compile-s3.yml
+++ b/.github/workflows/discovery-compile-s3.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: set credentials for AWS
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: "${{ secrets.AWS_CODEDEPLOY_ARN }}"
           aws-region: "${{ env.region }}"
@@ -49,18 +49,18 @@ jobs:
 
       - name: checkout repo with release
         if: "${{ env.release != '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ env.release }}"
 
       - name: checkout repo with branch
         if: "${{ env.release == '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.branch }}
 
       - name: add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506 # v1.1.3
         with:
           msbuild-architecture: x64
 

--- a/.github/workflows/discovery-copy-code-s3.yml
+++ b/.github/workflows/discovery-copy-code-s3.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
 
       - name: Install AWS CLI
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -52,7 +52,7 @@ jobs:
           pip install -r scripts/requirements-aws-cli.txt
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: "${{ env.region }}"

--- a/.github/workflows/discovery-deploy.yml
+++ b/.github/workflows/discovery-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       region: "eu-west-2"
     steps:
       - name: Install AWS CLI
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -39,7 +39,7 @@ jobs:
           pip install -r scripts/requirements-aws-cli.txt
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEDEPLOY_ARN }}
           aws-region: "${{ env.region }}"

--- a/.github/workflows/discovery-web-wincore.yml
+++ b/.github/workflows/discovery-web-wincore.yml
@@ -47,27 +47,27 @@ jobs:
     environment: ${{ inputs.account }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/discovery/${{ inputs.key_name }}
@@ -78,7 +78,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/ebs-preparation.yml
+++ b/.github/workflows/ebs-preparation.yml
@@ -59,27 +59,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/ansible/${{ inputs.key_name }}
@@ -90,7 +90,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/infrastructure-apply.yml
+++ b/.github/workflows/infrastructure-apply.yml
@@ -39,21 +39,21 @@ jobs:
 
     steps:
       - name: terraform setup
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.assume-role }}"
           role-session-name: PlaningSession
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ inputs.branch }}"
 

--- a/.github/workflows/infrastructure-plan.yml
+++ b/.github/workflows/infrastructure-plan.yml
@@ -39,21 +39,21 @@ jobs:
 
     steps:
       - name: terraform setup
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.assume-role }}"
           role-session-name: PlaningSession
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ inputs.branch }}"
 

--- a/.github/workflows/media-theme-deploy.yml
+++ b/.github/workflows/media-theme-deploy.yml
@@ -41,18 +41,18 @@ jobs:
     steps:
       - name: checkout repo with release
         if: "${{ env.release != '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ env.release }}"
 
       - name: checkout repo with branch
         if: "${{ env.release == '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.branch }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: "${{ env.region }}"
@@ -106,7 +106,7 @@ jobs:
     environment: "${{ inputs.github-environment }}"
     steps:
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
 
@@ -117,7 +117,7 @@ jobs:
           cp scripts/requirements-aws-cli.txt .
 
       - name: Install AWS CLI
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -128,7 +128,7 @@ jobs:
           pip install -r scripts/requirements-aws-cli.txt
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: "${{ env.region }}"

--- a/.github/workflows/media-wordpress-ami-build.yml
+++ b/.github/workflows/media-wordpress-ami-build.yml
@@ -84,27 +84,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/media/${{ inputs.key_name }}
@@ -115,7 +115,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/mysql-ami-build.yml
+++ b/.github/workflows/mysql-ami-build.yml
@@ -60,27 +60,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/mysql/${{ inputs.key_name }}
@@ -91,7 +91,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/plan-nginx.yml
+++ b/.github/workflows/plan-nginx.yml
@@ -36,23 +36,23 @@ jobs:
           region: eu-west-2
       steps:
           - name: Configure AWS Credentials
-            uses: aws-actions/configure-aws-credentials@v4
+            uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
             with:
                 aws-region: eu-west-2
                 role-to-assume: "${{ inputs.role-to-assume }}"
                 role-session-name: MySessionName
 
-          - uses: actions/setup-python@v5
+          - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
             with:
               python-version: '3.10' # Version range or exact version of a Python version to use, using SemVer's version range syntax
               architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
 
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
             with:
               ref: ${{ env.branch }}
 
-          - uses: hashicorp/setup-terraform@v2
+          - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 # only use if version freeze is in place
 #            with:
 #              terraform_version: 1.2.7

--- a/.github/workflows/postgres-ami-build.yml
+++ b/.github/workflows/postgres-ami-build.yml
@@ -57,27 +57,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/postgres/${{ inputs.key_name }}
@@ -88,7 +88,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/search-indexer.yml
+++ b/.github/workflows/search-indexer.yml
@@ -47,27 +47,27 @@ jobs:
     environment: ${{ inputs.account }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ github.event.inputs.branch }}"
 
       - name: checkout called workflow repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: 'nationalarchives/ds-github-actions'
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/discovery/${{ inputs.key_name }}
@@ -82,7 +82,7 @@ jobs:
 #          ls -lR ${{ github.workspace }}
 #
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
           cache: 'pip'

--- a/.github/workflows/services-backup-ami-build.yml
+++ b/.github/workflows/services-backup-ami-build.yml
@@ -38,26 +38,26 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-backup-kpf-administration/service-backups/${{ inputs.key_name }}
@@ -68,7 +68,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/taxonomy-indexer.yml
+++ b/.github/workflows/taxonomy-indexer.yml
@@ -47,20 +47,20 @@ jobs:
     environment: ${{ inputs.account }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ github.event.inputs.branch }}"
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/discovery/${{ inputs.key_name }}
@@ -71,7 +71,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/taxonomy-updater.yml
+++ b/.github/workflows/taxonomy-updater.yml
@@ -47,20 +47,20 @@ jobs:
     environment: ${{ inputs.account }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ github.event.inputs.branch }}"
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/discovery/${{ inputs.key_name }}
@@ -71,7 +71,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -26,22 +26,22 @@ jobs:
 
     steps:
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.assume-role }}"
           role-session-name: TFPlan
 
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: install terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.9.4
 

--- a/.github/workflows/website-nginx-ami-build.yml
+++ b/.github/workflows/website-nginx-ami-build.yml
@@ -57,27 +57,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/wp-website/${{ inputs.key_name }}
@@ -88,7 +88,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/website-static-content-deploy.yml
+++ b/.github/workflows/website-static-content-deploy.yml
@@ -42,19 +42,19 @@ jobs:
     steps:
       - name: checkout repo with release
         if: "${{ inputs.release != '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ inputs.release }}"
 
       - name: checkout repo with branch
         if: "${{ inputs.release == '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch }}
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
@@ -110,7 +110,7 @@ jobs:
     environment: "${{ inputs.github-environment }}"
     steps:
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
 
@@ -121,7 +121,7 @@ jobs:
           cp scripts/requirements-aws-cli.txt .
 
       - name: Install AWS CLI
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -133,7 +133,7 @@ jobs:
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"

--- a/.github/workflows/website-theme-deploy.yml
+++ b/.github/workflows/website-theme-deploy.yml
@@ -41,18 +41,18 @@ jobs:
     steps:
       - name: checkout repo with release
         if: "${{ env.release != '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "${{ env.release }}"
 
       - name: checkout repo with branch
         if: "${{ env.release == '' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.branch }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: "${{ env.region }}"
@@ -106,7 +106,7 @@ jobs:
     environment: "${{ inputs.github-environment }}"
     steps:
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
 
@@ -117,7 +117,7 @@ jobs:
           cp scripts/requirements-aws-cli.txt .
 
       - name: Install AWS CLI
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -128,7 +128,7 @@ jobs:
           pip install -r scripts/requirements-aws-cli.txt
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: "${{ env.region }}"

--- a/.github/workflows/website-wp-ami-build.yml
+++ b/.github/workflows/website-wp-ami-build.yml
@@ -87,27 +87,27 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: main
           ref: "${{ inputs.branch }}"
 
       - name: Checkout ds-github-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: nationalarchives/ds-github-actions
           path: actions
 
       - name: Configure AWS Credentials
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: "${{ inputs.region }}"
           role-to-assume: "${{ inputs.base_role }}"
           output-credentials: true
 
       - name: download key file
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53 # v1.0.0
         with:
           command: cp
           source: s3://ds-${{ inputs.account }}-kpf-administration/wp-website/${{ inputs.key_name }}
@@ -118,7 +118,7 @@ jobs:
           aws_region: ${{ inputs.region }}
 
       - name: install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
       - run: |


### PR DESCRIPTION
This PR pins third-party GitHub Actions to full commit SHAs for supply-chain security.

This has been done automatically by [pinact](https://github.com/suzuki-shunsuke/pinact). When reviewing please confirm that the SHAs are correct, zizmor will alert if not.

As a maintainer, please merge this PR once approved.